### PR TITLE
Add missing option to start service

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Finish the setup with the following steps:
 
 * Enable the service
 ```bash
-systemctl enable mediamonkeyserver.service
+systemctl --now enable mediamonkeyserver.service
 ```
 
 * Verify its status


### PR DESCRIPTION
`systemctl enable xyz` only enables the service to be started on next boot but doesn't start the service right now.
Therefore the `--now` option